### PR TITLE
developer need call MiddlewareInit by themself

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,13 @@ func main() {
 	if err != nil {
 		log.Fatal("JWT Error:" + err.Error())
 	}
-
+  
+  errInit := authMiddleware.MiddlewareInit()
+  
+	if errInit != nil {
+		log.Fatal("authMiddleware.MiddlewareInit() Error:" + errInit.Error())
+	}
+  
 	r.POST("/login", authMiddleware.LoginHandler)
 
 	r.NoRoute(authMiddleware.MiddlewareFunc(), func(c *gin.Context) {


### PR DESCRIPTION
after defind authMiddleware ,developer need call MiddlewareInit by themself  

we should add this code into  ```Example```

```go
        errInit := authMiddleware.MiddlewareInit()
  
	if errInit != nil {
		log.Fatal("authMiddleware.MiddlewareInit() Error:" + errInit.Error())
	}
```